### PR TITLE
Enable Vale Language Server for AsciiDoc Files

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -8,4 +8,4 @@ repository = "https://github.com/koozz/zed-vale"
 
 [language_servers.vale]
 name = "Vale Language Server"
-languages = ["Markdown", "AsciiDoc"]
+languages = ["AsciiDoc", "Markdown", "Plain Text"]

--- a/extension.toml
+++ b/extension.toml
@@ -8,4 +8,4 @@ repository = "https://github.com/koozz/zed-vale"
 
 [language_servers.vale]
 name = "Vale Language Server"
-language = "Markdown"
+languages = ["Markdown", "AsciiDoc"]


### PR DESCRIPTION
This pull request addresses my comment in https://github.com/koozz/zed-vale/issues/4. It enables the Vale language server for AsciiDoc files, in addition to Markdown files.
